### PR TITLE
Add language deprecation overlay to popup

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -12,10 +12,10 @@
     "message": "Thickness"
   },
   "BlinkLabel": {
-    "message": "Blink Animation"
+    "message": "Blink Mode"
   },
   "SmoothAnimationLabel": {
-    "message": "Typewriter Effect"
+    "message": "Typewriter Mode"
   },
   "TranslucentModeLabel": {
     "message": "Translucent Mode"

--- a/popup.html
+++ b/popup.html
@@ -475,6 +475,142 @@
       .live-preview-hr {
         border-color: white;
       }
+
+      /* Language deprecation overlay dark mode */
+      .lang-overlay-backdrop {
+        background: rgba(0, 0, 0, 0.75);
+      }
+
+      .lang-overlay-card {
+        background: #2a2a2a;
+        border-color: #444;
+      }
+
+      .lang-overlay-card h2 {
+        color: #f5f5f5;
+      }
+
+      .lang-overlay-card p {
+        color: #ccc;
+      }
+
+      .lang-overlay-card a {
+        color: #6db3f2;
+      }
+
+      .lang-overlay-dismiss {
+        background: #f5f5f5 !important;
+        color: #232323 !important;
+      }
+
+      .lang-overlay-dismiss:hover {
+        background: #e0e0e0 !important;
+      }
+
+      .lang-overlay-dont-show {
+        color: #999;
+      }
+
+      .lang-overlay-dont-show:hover {
+        color: #ccc;
+      }
+    }
+
+    /* Language Deprecation Overlay */
+    .lang-overlay-backdrop {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(255, 255, 255, 0.92);
+      z-index: 99999;
+      justify-content: center;
+      align-items: center;
+      padding: 24px;
+      box-sizing: border-box;
+    }
+
+    .lang-overlay-backdrop.visible {
+      display: flex;
+    }
+
+    .lang-overlay-card {
+      background: #fff;
+      border-radius: 12px;
+      border: 1px solid #e0e0e0;
+      padding: 28px 24px 24px;
+      max-width: 380px;
+      width: 100%;
+      text-align: left;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+    }
+
+    .lang-overlay-card h2 {
+      font-size: 16px;
+      font-weight: 600;
+      color: #222;
+      margin: 0 0 14px 0;
+      line-height: 1.4;
+    }
+
+    .lang-overlay-card p {
+      font-size: 13px;
+      color: #555;
+      line-height: 1.65;
+      margin: 0 0 20px 0;
+    }
+
+    .lang-overlay-card a {
+      color: #4285F4;
+      text-decoration: underline;
+    }
+
+    .lang-overlay-card a:hover {
+      color: #1a5dc7;
+    }
+
+    .lang-overlay-dismiss {
+      display: block;
+      width: 100%;
+      padding: 12px;
+      font-size: 13px;
+      font-weight: 600;
+      font-family: 'Inter', sans-serif;
+      border: none;
+      border-radius: 8px;
+      background: #333;
+      color: #fff;
+      cursor: pointer;
+      transition: background 0.2s ease;
+      text-align: center;
+    }
+
+    .lang-overlay-dismiss:hover {
+      background: #555;
+    }
+
+    .lang-overlay-dont-show {
+      display: block;
+      width: 100%;
+      padding: 10px;
+      margin-top: 8px;
+      font-size: 12px;
+      font-family: 'Inter', sans-serif;
+      border: none;
+      border-radius: 8px;
+      background: transparent;
+      color: #888;
+      cursor: pointer;
+      transition: color 0.2s ease;
+      text-align: center;
+    }
+
+    .lang-overlay-dont-show:hover {
+      color: #555;
+      text-decoration: underline;
+      background: transparent;
     }
   </style>
 </head>
@@ -537,6 +673,23 @@
     <div class="action-buttons">
       <button class="save-button" id="saveButton"></button>
       <button class="maker-button" id="maker"></button>
+    </div>
+
+    <!-- Language Deprecation Overlay -->
+    <div class="lang-overlay-backdrop" id="langOverlay">
+      <div class="lang-overlay-card">
+        <h2>Upcoming Language Removal</h2>
+        <p>
+          I'm a solo developer, and while I've enjoyed offering many language options, maintaining them has become
+          difficult. The current AI translations are not very accurate, and I don't want to give you a confusing
+          experience. Because of this, support for your language will be removed in the coming weeks. If you'd like to
+          help by providing a translation for your language, you can <a
+            href="https://github.com/asahisuenaga/rainbow-cursor/issues/3#issue-3935173407" target="_blank">learn
+            more</a>.
+        </p>
+        <button class="lang-overlay-dismiss" id="langOverlayDismiss">OK</button>
+        <button class="lang-overlay-dont-show" id="langOverlayDontShow">Don't show again</button>
+      </div>
     </div>
 
     <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -29,6 +29,32 @@ document.addEventListener('DOMContentLoaded', () => {
   const optionsContainer = document.getElementById("optionsContainer");
   const livePreviewSection = document.getElementById('livePreviewSection');
 
+  // --- Language Deprecation Overlay ---
+  function maybeShowLangOverlay() {
+    const uiLang = (chrome.i18n.getUILanguage() || '').toLowerCase().replace('-', '_');
+    const supportedLangs = ['en', 'ja'];
+    const isSupported = supportedLangs.some(lang => uiLang === lang || uiLang.startsWith(lang + '_'));
+    if (isSupported) return;
+
+    chrome.storage.sync.get(['langOverlayDismissed'], (result) => {
+      if (result.langOverlayDismissed) return;
+
+      const overlay = document.getElementById('langOverlay');
+      if (!overlay) return;
+
+      overlay.classList.add('visible');
+
+      document.getElementById('langOverlayDismiss').addEventListener('click', () => {
+        overlay.classList.remove('visible');
+      });
+
+      document.getElementById('langOverlayDontShow').addEventListener('click', () => {
+        chrome.storage.sync.set({ langOverlayDismissed: true });
+        overlay.classList.remove('visible');
+      });
+    });
+  }
+
   // Helper function to set localized text
   function setLocalizedText(id, messageKey) {
     const element = document.getElementById(id);
@@ -99,6 +125,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (redirectContainer) redirectContainer.style.display = 'none';
       if (livePreviewSection) livePreviewSection.style.display = 'block';
       updateSettingsLivePreview();
+
+      // Show language deprecation overlay only in Google Docs
+      maybeShowLangOverlay();
     }
   });
 


### PR DESCRIPTION
Introduce a Language Deprecation Overlay in the popup UI (HTML + CSS) and add JS to control its behavior. The overlay notifies users that certain localized languages will be removed, links to a GitHub issue for contribution, and provides 'OK' and 'Don't show again' actions. popup.js adds maybeShowLangOverlay() to detect the UI language (supported: en, ja), check chrome.storage.sync.langOverlayDismissed, show the overlay for unsupported locales, and persist the "don't show again" choice. Also rename two locale messages: "Blink Animation" -> "Blink Mode" and "Typewriter Effect" -> "Typewriter Mode".